### PR TITLE
Fix Android app crashes (missing INTERNET permission and duplicate LazyColumn key)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/android/app/src/main/java/com/example/grocery/ui/GroceryListScreen.kt
+++ b/android/app/src/main/java/com/example/grocery/ui/GroceryListScreen.kt
@@ -188,10 +188,14 @@ fun GroceryListScreen(
                             when (dismissValue) {
                                 SwipeToDismissBoxValue.EndToStart -> {
                                     repository.deleteItem(item)
+                                    activeItems = activeItems.filter { i -> i.id != item.id }
+                                    if (selectedItemId == item.id) selectedItemId = null
                                     true
                                 }
                                 SwipeToDismissBoxValue.StartToEnd -> {
                                     repository.toggleCompletion(item)
+                                    activeItems = activeItems.filter { i -> i.id != item.id }
+                                    if (selectedItemId == item.id) selectedItemId = null
                                     true
                                 }
                                 else -> false
@@ -248,8 +252,15 @@ fun GroceryListScreen(
 
                              GroceryItemRow(
                                 item = item,
-                                onToggle = { repository.toggleCompletion(it) },
-                                onDelete = { repository.deleteItem(it) },
+                                onToggle = { 
+                                    repository.toggleCompletion(it)
+                                    activeItems = activeItems.filter { i -> i.id != it.id }
+                                },
+                                onDelete = { 
+                                    repository.deleteItem(it)
+                                    activeItems = activeItems.filter { i -> i.id != it.id }
+                                    if (selectedItemId == it.id) selectedItemId = null
+                                },
                                 onNameChange = { item, newName -> 
                                     repository.updateName(item, newName)
                                 },


### PR DESCRIPTION
This PR fixes two underlying issues causing the Android application to crash or fail to load data:

1. **Missing INTERNET Permission**: The app lacked the `android.permission.INTERNET` permission in `AndroidManifest.xml`, which caused a `java.net.UnknownHostException` (EAI_NODATA) when attempting to resolve `firestore.googleapis.com` and connect to the database.
2. **Duplicate Key in LazyColumn**: A recent PR removed optimistic local updates from `GroceryListScreen`. Because `activeItems` is updated asynchronously (via `LaunchedEffect`) and `completedItems` is updated synchronously, marking an item as completed caused its ID to briefly appear in both lists simultaneously, leading to an `IllegalArgumentException: Key was already used` crash in the `LazyColumn`. This PR restores the optimistic UI updates to prevent this race condition.