### PR TITLE
Add share sheet support to receive text from other apps

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,11 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
         </activity>
     </application>
 

--- a/android/app/src/main/java/com/example/grocery/MainActivity.kt
+++ b/android/app/src/main/java/com/example/grocery/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.example.grocery
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -12,12 +13,25 @@ import androidx.compose.ui.Modifier
 import com.example.grocery.data.GroceryRepository
 import com.example.grocery.ui.GroceryListScreen
 import com.example.grocery.ui.theme.GroceryListTheme
+import com.example.grocery.util.PasteUtils
 
 class MainActivity : ComponentActivity() {
     private val repository = GroceryRepository() // In a real app, use Hilt/Koin injection
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        if (intent?.action == Intent.ACTION_SEND && intent.type == "text/plain") {
+            val sharedText = intent.getStringExtra(Intent.EXTRA_TEXT) ?: ""
+            if (sharedText.isNotBlank()) {
+                val result = PasteUtils.processInput("", sharedText)
+                val allItems = listOfNotNull(result.updatedCurrentText.takeIf { it.isNotEmpty() }) + result.newItems
+                if (allItems.isNotEmpty()) {
+                    repository.addItems(allItems)
+                }
+            }
+        }
+
         setContent {
             GroceryListTheme {
                 Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {


### PR DESCRIPTION
## Changes

- **AndroidManifest.xml**: Added intent filter to MainActivity to handle `ACTION_SEND` with `text/plain` MIME type, enabling the app to receive shared text from other applications
- **MainActivity.kt**: Implemented logic in `onCreate()` to process shared text intent data using `PasteUtils` and automatically add parsed items to the grocery list repository

## Details

Users can now share text (e.g., grocery lists) directly to this app from any other application. The shared text is parsed and automatically added to the grocery list.