### PR TITLE
Add "Delete all items" option to three-dot menu

### DIFF
--- a/android/app/src/androidTest/java/com/example/grocery/GroceryListScreenTest.kt
+++ b/android/app/src/androidTest/java/com/example/grocery/GroceryListScreenTest.kt
@@ -2,6 +2,7 @@ package com.example.grocery
 
 
 
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -79,5 +80,77 @@ class GroceryListScreenTest {
 
         // Assert
         verify(exactly = 1) { repository.undoLastAction() }
+    }
+
+    @Test
+    fun deleteAllItems_menuItem_isVisible() {
+        val repository = mockk<GroceryRepository>(relaxed = true)
+        every { repository.items } returns flowOf(listOf(GroceryItem("id1", "Milk", false, 0, Date())))
+
+        composeTestRule.setContent {
+            GroceryListScreen(repository = repository)
+        }
+
+        composeTestRule.onNodeWithContentDescription("Menu").performClick()
+
+        composeTestRule.onNodeWithText("Delete all items").assertIsDisplayed()
+    }
+
+    @Test
+    fun deleteAllItems_showsConfirmationDialog_andDoesNotDeleteImmediately() {
+        val repository = mockk<GroceryRepository>(relaxed = true)
+        every { repository.items } returns flowOf(listOf(GroceryItem("id1", "Milk", false, 0, Date())))
+
+        composeTestRule.setContent {
+            GroceryListScreen(repository = repository)
+        }
+
+        composeTestRule.onNodeWithContentDescription("Menu").performClick()
+        composeTestRule.onNodeWithText("Delete all items").performClick()
+
+        composeTestRule.onNodeWithText("Delete all items?").assertIsDisplayed()
+        verify(exactly = 0) { repository.deleteItems(any()) }
+    }
+
+    @Test
+    fun deleteAllItems_cancelDoesNotCallDeleteItems() {
+        val repository = mockk<GroceryRepository>(relaxed = true)
+        every { repository.items } returns flowOf(listOf(GroceryItem("id1", "Milk", false, 0, Date())))
+
+        composeTestRule.setContent {
+            GroceryListScreen(repository = repository)
+        }
+
+        composeTestRule.onNodeWithContentDescription("Menu").performClick()
+        composeTestRule.onNodeWithText("Delete all items").performClick()
+        composeTestRule.onNodeWithText("Cancel").performClick()
+
+        verify(exactly = 0) { repository.deleteItems(any()) }
+    }
+
+    @Test
+    fun deleteAllItems_confirmCallsDeleteItemsWithAllItems() {
+        val repository = mockk<GroceryRepository>(relaxed = true)
+
+        val activeItem = GroceryItem("id1", "Milk", false, 0, Date())
+        val completedItem1 = GroceryItem("id2", "Eggs", true, 1, Date())
+        val completedItem2 = GroceryItem("id3", "Bread", true, 2, Date())
+        val allItems = listOf(activeItem, completedItem1, completedItem2)
+
+        every { repository.items } returns flowOf(allItems)
+
+        composeTestRule.setContent {
+            GroceryListScreen(repository = repository)
+        }
+
+        composeTestRule.onNodeWithContentDescription("Menu").performClick()
+        composeTestRule.onNodeWithText("Delete all items").performClick()
+        composeTestRule.onNodeWithText("Delete").performClick()
+
+        verify {
+            repository.deleteItems(match { items ->
+                items.size == 3 && items.containsAll(allItems)
+            })
+        }
     }
 }

--- a/android/app/src/main/java/com/example/grocery/ui/GroceryListScreen.kt
+++ b/android/app/src/main/java/com/example/grocery/ui/GroceryListScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -35,6 +36,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
@@ -112,6 +114,7 @@ fun GroceryListScreen(
     val coroutineScope = rememberCoroutineScope()
 
     var isSortingInProgress by remember { mutableStateOf(false) }
+    var showDeleteAllConfirmation by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -155,6 +158,13 @@ fun GroceryListScreen(
                                 }
                             )
                             DropdownMenuItem(
+                                text = { Text(stringResource(R.string.delete_all_items)) },
+                                onClick = {
+                                    showDeleteAllConfirmation = true
+                                    showMenu = false
+                                }
+                            )
+                            DropdownMenuItem(
                                 text = { Text("Undo") },
                                 onClick = {
                                     repository.undoLastAction()
@@ -173,6 +183,23 @@ fun GroceryListScreen(
             )
         }
     ) { innerPadding ->
+        if (showDeleteAllConfirmation) {
+            AlertDialog(
+                onDismissRequest = { showDeleteAllConfirmation = false },
+                title = { Text("Delete all items?") },
+                text = { Text("This will remove all ${items.size} items from your list.") },
+                confirmButton = {
+                    TextButton(onClick = {
+                        repository.deleteItems(items)
+                        showDeleteAllConfirmation = false
+                    }) { Text("Delete") }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showDeleteAllConfirmation = false }) { Text("Cancel") }
+                }
+            )
+        }
+
         LazyColumn(
             state = state.listState,
             modifier = modifier

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name">Grocery List</string>
     <string name="sort_by_section">Sort by Section</string>
     <string name="delete_all_checked_items">Delete all checked items</string>
+    <string name="delete_all_items">Delete all items</string>
 </resources>

--- a/android/app/src/test/java/com/example/grocery/data/GroceryRepositoryTest.kt
+++ b/android/app/src/test/java/com/example/grocery/data/GroceryRepositoryTest.kt
@@ -138,6 +138,34 @@ class GroceryRepositoryTest {
     }
 
     @Test
+    fun `deleteItems with mixed active and completed items records DeleteItems action`() {
+        // Arrange
+        val items = listOf(
+            GroceryItem("id1", "Milk", false, 0, Date()),
+            GroceryItem("id2", "Eggs", true, 1, Date()),
+            GroceryItem("id3", "Bread", true, 2, Date())
+        )
+
+        // Act
+        testRepository.deleteItems(items)
+
+        // Assert
+        val action = testRepository.lastAction
+        assertTrue(action is GroceryRepository.GroceryAction.DeleteItems)
+        action as GroceryRepository.GroceryAction.DeleteItems
+        assertEquals(items, action.items)
+    }
+
+    @Test
+    fun `deleteItems with empty list does not record action`() {
+        // Act
+        testRepository.deleteItems(emptyList())
+
+        // Assert
+        assertNull(testRepository.lastAction)
+    }
+
+    @Test
     fun `undoLastAction clears lastAction`() {
         // Arrange
         val item = GroceryItem("id1", "Milk", false, 0, Date())


### PR DESCRIPTION
Adds a new menu item that deletes all checklist items (both active and
completed) behind a confirmation dialog to prevent accidental deletion.
Reuses the existing deleteItems() batch Firestore operation, preserving
undo support. Includes 4 new instrumented UI tests and 2 new unit tests.

https://claude.ai/code/session_01NT7Nw7dWzDtrxPTZ66tGNj