### PR TITLE
fix: add Firebase Anonymous Auth so Firestore writes succeed

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -94,6 +94,7 @@ dependencies {
     implementation(platform("com.google.firebase:firebase-bom:32.7.0"))
     implementation("com.google.firebase:firebase-firestore")
     implementation("com.google.firebase:firebase-analytics")
+    implementation("com.google.firebase:firebase-auth")
 
     // Gemini AI
     implementation("com.google.ai.client.generativeai:generativeai:0.9.0")

--- a/android/app/src/main/java/com/example/grocery/data/GroceryRepository.kt
+++ b/android/app/src/main/java/com/example/grocery/data/GroceryRepository.kt
@@ -3,6 +3,7 @@ package com.example.grocery.data
 import android.util.Log
 import com.example.grocery.model.GroceryItem
 import com.example.grocery.util.GeminiAisleSorter
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import kotlinx.coroutines.channels.awaitClose
@@ -14,6 +15,15 @@ class GroceryRepository {
     private val db = FirebaseFirestore.getInstance()
     private val collection = db.collection("groceries")
     private val geminiAisleSorter = GeminiAisleSorter()
+
+    init {
+        val auth = FirebaseAuth.getInstance()
+        if (auth.currentUser == null) {
+            auth.signInAnonymously()
+                .addOnSuccessListener { Log.d("GroceryRepository", "Signed in anonymously: ${it.user?.uid}") }
+                .addOnFailureListener { e -> Log.e("GroceryRepository", "Anonymous sign-in failed", e) }
+        }
+    }
 
     sealed class GroceryAction {
         data class DeleteItem(val item: GroceryItem) : GroceryAction()


### PR DESCRIPTION
All Firestore writes (add, delete, toggle) were failing with PERMISSION_DENIED because the app had no authentication. This adds anonymous sign-in on GroceryRepository init so every write goes through an authenticated session, fixing the '+ List item' button bug.

https://claude.ai/code/session_01NT7Nw7dWzDtrxPTZ66tGNj